### PR TITLE
🐛 app.setAppUserModelId() is executed when in dev mode in Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -163,6 +163,8 @@ if (!isDev) {
   })
 }
 
+if (isDev && process.platform == 'win32') app.setAppUserModelId(process.execPath)
+
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On macOS it is common for applications and their menu bar


### PR DESCRIPTION
Forgot to put this in the other branch. Sorry.